### PR TITLE
Subnet Creation Optimization

### DIFF
--- a/AngularApp1.Server/AngularApp1.Server.csproj
+++ b/AngularApp1.Server/AngularApp1.Server.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="EFCore.BulkExtensions" Version="8.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy">

--- a/AngularApp1.Server/appsettings.json
+++ b/AngularApp1.Server/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=subnets;User=root;Password=root;"
+    "DefaultConnection": "Server=localhost;Database=subnets;User=root;Password=root;AllowLoadLocalInfile=true;"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Used the `BulkInsert` function from `EFCore.BulkExtensions` library to make large inserts faster

Note: I tried doing bulk inserts using normal EFCore methods like saving at last or using `AddRange` function but for some reason it insisted on inserting one by one 

### To make sure this will work with MySQL:
1. **Check MySQL Server Configuration**: Ensure that `local_infile` is enabled on the MySQL server. You can check and enable this by running the following query on your MySQL server:
```
SHOW GLOBAL VARIABLES LIKE 'local_infile';
```
If it's set to OFF, you can enable it:
```
SET GLOBAL local_infile = 1;
```
Update the MySQL configuration file (my.cnf or my.ini) to ensure that the setting is enabled after a server restart:
```
[mysqld]
local_infile=1
```

2. Restart MySQL Service: After changing the configuration file, restart the MySQL service to apply the changes.